### PR TITLE
Fix file path in RIFLE/run.py

### DIFF
--- a/RIFLE/run.py
+++ b/RIFLE/run.py
@@ -2,14 +2,11 @@ from RobustImputer import RobustImputer
 import sys
 
 
-ind = sys.argv[1]
+missing, imputed = sys.argv[1:3]
 imputer = RobustImputer()
 
-print(ind)
-# imputer.read_and_scale('drive_MCAR80_' + str(n) + '.csv')
-imputer.read_and_scale('missing_BC_MCAR20.csv')
+imputer.read_and_scale(missing)
 imputer.estimate_confidence_intervals()
 imputer.impute()
 
-# imputer.write_to_csv('drive_imputed_MCAR80_' + str(n) + '.csv')
-imputer.write_to_csv('imputed_BC_MCAR20_instance' + str(ind) + '.csv')
+imputer.write_to_csv(imputed)


### PR DESCRIPTION
Hi there, perhaps you accidentally hardcoded the file paths in `RIFLE/run.py`. I changed it to read from command line arguments. Does that make sense? Thanks!